### PR TITLE
The memory fix update

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ To see that the data structures are working correctly, you can use `valgrind` to
 valgrind ./stl_test
 ```
 
+## Memory
+
+The web build also uses a custom `malloc`.
+
+**If the game is crashing, try increasing `MALLOC_PAD_SPACE`.**
+
 # Performance
 
 fcsim promised to be fast. So how fast is it?

--- a/arch/wasm/include/stl_mock.h
+++ b/arch/wasm/include/stl_mock.h
@@ -6,6 +6,10 @@
 #include "string.h"
 #include "stl_compat.h"
 
+#ifndef VECTOR_DEFAULT_CAPACITY
+#define VECTOR_DEFAULT_CAPACITY 8
+#endif
+
 // issues:
 // * wrong behaviour for address-sensitive types
 // * * new
@@ -38,7 +42,7 @@ struct vector {
     size_t _capacity;
     size_t _size;
     vector() {
-        _capacity = 8;
+        _capacity = VECTOR_DEFAULT_CAPACITY;
         _size = 0;
         _storage = (T*)malloc(_capacity * sizeof(T));
     }

--- a/src/arch/wasm/malloc.c
+++ b/src/arch/wasm/malloc.c
@@ -15,13 +15,23 @@
 // so I set the pad space accordingly
 // and the game does not crash.
 // in the future, if the game is crashing, try setting the pad space higher.
+#ifndef MALLOC_PAD_SPACE
+#define MALLOC_PAD_SPACE 160000
+#endif
+#ifndef MALLOC_MIN_BLOCK
+#define MALLOC_MIN_BLOCK 4
+#endif
+#ifndef MALLOC_INITIAL_ROOT
+#define MALLOC_INITIAL_ROOT MALLOC_MIN_BLOCK
+#endif
+
 #define SIZE_SIZE_T 4
-const size_t __min_block_size = 1 << 4;
-const size_t __pad_space = 160000;
+const size_t __min_block_size = 1 << MALLOC_MIN_BLOCK;
+const size_t __pad_space = MALLOC_PAD_SPACE;
 
 extern unsigned char __heap_base;
 size_t __first_free = (size_t)&__heap_base;
-size_t __root_size = 1 << 8;
+size_t __root_size = 1 << MALLOC_INITIAL_ROOT;
 int __memory_status = 0;
 
 size_t memory_size(void) {

--- a/src/arch/wasm/malloc.c
+++ b/src/arch/wasm/malloc.c
@@ -6,9 +6,18 @@
 // https://github.com/miguelperes/custom-malloc
 // block layout: [size][next][prev]
 
+// about the pad space:
+// before this variable was introduced, the game crashes
+// (try setting it to 0, see for yourself)
+// small values also don't work
+// I suspect it has to do with the memory taken by the program itself
+// at the time of writing, that is around 160 KB
+// so I set the pad space accordingly
+// and the game does not crash.
+// in the future, if the game is crashing, try setting the pad space higher.
 #define SIZE_SIZE_T 4
 const size_t __min_block_size = 1 << 4;
-const size_t __pad_space = 10000000;
+const size_t __pad_space = 160000;
 
 extern unsigned char __heap_base;
 size_t __first_free = (size_t)&__heap_base;
@@ -26,35 +35,8 @@ size_t memory_grow(int delta) {
 void _ensure_root_size(size_t total) {
   total += __pad_space;
   size_t size = memory_size()<<16;
-  printf("ensure root %d %d\n", size, total);
   if (total > size) {
     size_t retcode = memory_grow( (total>>16)-(size>>16)+1 );
-  }
-  /*
-  size_t size;
-  while((size = memory_size() << 16) < total) {
-    memory_grow(1);
-  }
-  */
-}
-
-void print_node(size_t cur_block) {
-  size_t before = ((size_t*)cur_block)[2];
-  size_t after = ((size_t*)cur_block)[1];
-  size_t size = ((size_t*)cur_block)[0];
-  printf("addr = %d | size = %d | next = %d | prev = %d\n", cur_block, size, after, before);
-}
-
-void check_node_integrity(size_t cur_block) {
-  size_t before = ((size_t*)cur_block)[2];
-  size_t after = ((size_t*)cur_block)[1];
-  size_t before_after = ((size_t*)after)[2];
-  size_t after_before = ((size_t*)before)[1];
-  if(cur_block != before_after || cur_block != after_before) {
-    printf("node error! %d\n", 0);
-    print_node(cur_block);
-    print_node(after);
-    print_node(before);
   }
 }
 
@@ -68,8 +50,6 @@ void _remove_block(size_t block) {
   size_t before = ((size_t*)block)[2];
   size_t after = ((size_t*)block)[1];
   _link_block(before, after);
-  check_node_integrity(before);
-  check_node_integrity(after);
   // fix first
   if(__first_free == block) {
     // set to something else
@@ -100,17 +80,9 @@ void _append_tail(size_t r) {
 size_t _malloc_search_block(size_t n) {
   // search for suitable block
   size_t cur_block = __first_free;
-  int iter = 0;
   do{
-    iter++;if(iter>30){
-      printf("iter limit reached, giving up %d\n", 0);
-      //return NULL+1;
-    }
     size_t cur_block_size = ((size_t*)cur_block)[0];
     size_t next_block = ((size_t*)cur_block)[1];
-    check_node_integrity(cur_block);
-    check_node_integrity(next_block);
-    printf("checking block | addr = %d | size = %d | next = %d | prev = %d | first = %d\n", cur_block, cur_block_size, next_block, ((size_t*)cur_block)[2], __first_free);
     if(cur_block_size < n) {
       cur_block = next_block;
       continue;
@@ -124,13 +96,7 @@ size_t _malloc_search_block(size_t n) {
       size_t sibling_block = cur_block + cur_block_size;
       ((size_t*)sibling_block)[0] = ((size_t*)cur_block)[0] = cur_block_size;
       _append_tail(sibling_block);
-      printf("splitting block %d %d %d\n", cur_block, sibling_block, cur_block_size);
-      check_node_integrity(sibling_block);
-      check_node_integrity(cur_block);
-      check_node_integrity(__first_free);
     }
-    check_node_integrity(__first_free);
-    check_node_integrity(cur_block);
     _remove_block(cur_block);
     return cur_block + SIZE_SIZE_T * 3;
   }while(cur_block != __first_free);
@@ -139,7 +105,6 @@ size_t _malloc_search_block(size_t n) {
 }
 
 void* malloc(size_t n) {
-  printf("malloc %d\n", n);
   // word size assumptions
   _Static_assert(sizeof(size_t) == SIZE_SIZE_T);
   // 0 case
@@ -164,7 +129,6 @@ void* malloc(size_t n) {
     _link_block(__first_free, __first_free);
     __root_size <<= 1;
   }
-  check_node_integrity(__first_free);
   // search for suitable block
   size_t result = _malloc_search_block(n);
   if(result != NULL)return result;
@@ -175,9 +139,6 @@ void* malloc(size_t n) {
     ((size_t*)big_block)[0] = __root_size;
     _append_tail(big_block);
     __root_size <<= 1;
-    printf("root expanded %d\n", __root_size);
-    check_node_integrity(__first_free);
-    check_node_integrity(big_block);
   }while((__root_size >> 1) < n);
   // there will definitely be a block available this time
   return _malloc_search_block(n);
@@ -198,12 +159,6 @@ void free(void* p) {
   if (p == NULL) return;
   size_t r=(size_t)p;
   r-=SIZE_SIZE_T*3;
-  printf("free %d %d\n", p, r);
-  // already free? should never happen
-  if(((size_t*)r)[1] != NULL) {
-    printf("already freed %d %d\n", r, r+SIZE_SIZE_T*3);
-    return;
-  }
   // try to merge siblings
   size_t r_size = ((size_t*)r)[0];
   while(1) {
@@ -211,46 +166,31 @@ void free(void* p) {
       // already the largest
       break;
     }
-    size_t sibling_block, sibling_block_next, sibling_block_size;
-    if((r - root + r_size) & r_size) {
+    size_t sibling_block;
+    size_t is_on_right = (r - root + r_size) & r_size;
+    if(is_on_right) {
       // sibling on right
       sibling_block = r + r_size;
-      sibling_block_next = ((size_t*)sibling_block)[1];
-      if(sibling_block_next == NULL) {
-        // sibling is in use, can't merge further
-        break;
-      }
-      sibling_block_size = ((size_t*)sibling_block)[0];
-      if(sibling_block_size != r_size) {
-        // sibling has wrong size (possibly split), can't merge further
-        break;
-      }
-      check_node_integrity(sibling_block);
-      printf("merge right %d %d %d\n", r, sibling_block, r_size);
-      _remove_block(sibling_block);
-      ((size_t*)r)[0] = r_size = r_size << 1;
     } else {
       // sibling on left
       sibling_block = r - r_size;
-      sibling_block_next = ((size_t*)sibling_block)[1];
-      if(sibling_block_next == NULL) {
-        // sibling is in use, can't merge further
-        break;
-      }
-      sibling_block_size = ((size_t*)sibling_block)[0];
-      if(sibling_block_size != r_size) {
-        // sibling has wrong size (possibly split), can't merge further
-        break;
-      }
-      check_node_integrity(sibling_block);
-      printf("merge left %d %d %d\n", r, sibling_block, r_size);
-      _remove_block(sibling_block);
-      r = sibling_block;
-      ((size_t*)r)[0] = r_size = r_size << 1;
     }
+    size_t sibling_block_next = ((size_t*)sibling_block)[1];
+    if(sibling_block_next == NULL) {
+      // sibling is in use, can't merge further
+      break;
+    }
+    size_t sibling_block_size = ((size_t*)sibling_block)[0];
+    if(sibling_block_size != r_size) {
+      // sibling has wrong size (possibly split), can't merge further
+      break;
+    }
+    _remove_block(sibling_block);
+    if(!is_on_right) {
+      r = sibling_block;
+    }
+    ((size_t*)r)[0] = r_size = r_size << 1;
   }
   // add block back to free list
   _append_tail(r);
-  check_node_integrity(r);
-  check_node_integrity(__first_free);
 }

--- a/src/arch/wasm/malloc.c
+++ b/src/arch/wasm/malloc.c
@@ -1,14 +1,18 @@
 #include <stddef.h>
 #include <string.h>
 
-#define _mem_alignment 4
-#define _size_t_bytes sizeof(size_t)
-#define _mem_flag_used 0xbf82583a
-#define _mem_flag_free 0xab34d705
+// cell bisecting implementation of malloc
+// as described in
+// https://github.com/miguelperes/custom-malloc
+// block layout: [size][next][prev]
+
+#define SIZE_SIZE_T 4
 
 extern unsigned char __heap_base;
-size_t __heap_tail = (size_t)&__heap_base;
-size_t __heap_mark = (size_t)&__heap_base;
+size_t __first_free = (size_t)&__heap_base;
+size_t __root_size = 1 << 8;
+const size_t __min_block_size = 1 << 4;
+int __memory_status = 0;
 
 size_t memory_size(void) {
   return __builtin_wasm_memory_size(0);
@@ -18,44 +22,125 @@ size_t memory_grow(int delta) {
     return __builtin_wasm_memory_grow(0, delta);
 }
 
-void free_all() {
-  __heap_tail = __heap_mark;
-}
-
-void free_all_mark() {
-  __heap_mark = __heap_tail;
-}
-
-void* free_get_mark() {
-  return (void *)__heap_tail;
-}
-
-void free_to_mark(void *mark) {
-  __heap_tail = (size_t)mark;
-}
-
-
-void* malloc(size_t n) {
-  // size is marked at both ends to construct a pointer of previous block
-  // [4b:size][4b:flag][n:allocated][4b:size]
-
-  n += (8 - (n % _mem_alignment)) % _mem_alignment;
-  // check if size is enough
-  size_t total = __heap_tail + n + 3*_size_t_bytes;
+void _ensure_root_size(size_t total) {
   size_t size = memory_size()<<16;
   if (total > size) {
-    memory_grow( (total>>16)-(size>>16)+1 );
+    size_t retcode = memory_grow( (total>>16)-(size>>16)+1 );
+    printf("%d\n", retcode);
   }
-  unsigned int r = __heap_tail;
-  *((size_t *)r)=n;
-  r+= _size_t_bytes;
-  *((size_t *)r)=_mem_flag_used;
-  r+= _size_t_bytes;
-  __heap_tail = r + n;
-  *((size_t *)__heap_tail) = n;
-  __heap_tail += _size_t_bytes;
-  
-  return (void *)r;
+  /*
+  size_t size;
+  while((size = memory_size() << 16) < total) {
+    memory_grow(1);
+  }
+  */
+}
+
+void _link_block(size_t before, size_t after) {
+  ((size_t*)before)[1] = after;
+  ((size_t*)after)[2] = before;
+}
+
+void _remove_block(size_t block) {
+  size_t before = ((size_t*)block)[2];
+  size_t after = ((size_t*)block)[1];
+  _link_block(before, after);
+}
+
+size_t _malloc_search_block(size_t n) {
+  // search for suitable block
+  size_t cur_block = __first_free;
+  do{
+    size_t cur_block_size = ((size_t*)cur_block)[0];
+    size_t next_block = ((size_t*)cur_block)[1];
+    if(cur_block_size < n) {
+      cur_block = next_block;
+      continue;
+    }
+    // this block is large enough
+    // split the block if it's too large
+    // but still above the minimum size
+    while(cur_block_size > __min_block_size && 2 * n <= cur_block_size) {
+      // mitosis
+      cur_block_size >>= 1;
+      size_t sibling_block = cur_block + cur_block_size;
+      ((size_t*)sibling_block)[0] = cur_block_size;
+      _link_block(cur_block, sibling_block);
+      _link_block(sibling_block, next_block);
+      next_block = sibling_block;
+    }
+    // take the block
+    if(__first_free == cur_block) {
+      // it's not free now
+      // set it to something else
+      __first_free = next_block;
+      // if it's the only block
+      if(__first_free == cur_block) {
+        // indicate with a status
+        __memory_status = 2;
+      }
+    }
+    _remove_block(cur_block);
+    ((size_t*)cur_block)[1] = NULL; // mark used
+    return cur_block + SIZE_SIZE_T * 3;
+  }while(cur_block != __first_free);
+  // failed to find a block
+  return NULL;
+}
+
+void _append_tail(size_t r) {
+  if(__memory_status == 2) {
+    // all blocks were used, now we have a block
+    __first_free = r;
+    _link_block(__first_free, __first_free);
+    return;
+  }
+  // add block back to list
+  size_t second_free = ((size_t*)__first_free)[1];
+  _link_block(__first_free, r);
+  _link_block(r, second_free);
+}
+
+void* malloc(size_t n) {
+  // word size assumptions
+  _Static_assert(sizeof(size_t) == SIZE_SIZE_T);
+  // 0 case
+  if(n == 0)return NULL;
+  // alignment
+  n = -((-n) & ~(SIZE_SIZE_T - 1));
+  // account for header size
+  n += SIZE_SIZE_T * 3;
+  // first time: init available memory
+  if(__memory_status == 0) {
+    __memory_status = 1;
+    _ensure_root_size(__root_size);
+    ((size_t*)__first_free)[0] = __root_size;
+    _link_block(__first_free, __first_free);
+  }
+  // all memory used: expand
+  if(__memory_status == 2) {
+    __memory_status = 1;
+    _ensure_root_size(__root_size << 1);
+    __first_free = ((size_t)&__heap_base) + __root_size;
+    ((size_t*)__first_free)[0] = __root_size;
+    _link_block(__first_free, __first_free);
+    __root_size <<= 1;
+  }
+  // search for suitable block
+  size_t result = _malloc_search_block(n);
+  if(result != NULL)return result;
+  // memory available, but no blocks large enough: expand
+  do {
+    _ensure_root_size(__root_size << 1);
+    size_t big_block = ((size_t)&__heap_base) + __root_size;
+    ((size_t*)big_block)[0] = __root_size;
+    _append_tail(big_block);
+    __root_size <<= 1;
+    printf("%d\n", __root_size);
+    if(__root_size >= (1 << 17))return NULL;
+  }while((__root_size >> 1) < n);
+  // there will definitely be a block available this time
+  return _malloc_search_block(n);
 }
 
 void *calloc(size_t nmemb, size_t size)
@@ -67,38 +152,43 @@ void *calloc(size_t nmemb, size_t size)
 }
 
 void free(void* p) {
-  
+  const size_t root = (size_t)&__heap_base;
   size_t n;
   // null case
-  if (!p) return;
+  if (p == NULL) return;
   size_t r=(size_t)p;
-  r-=_size_t_bytes;
-  // already free
-  if (*((size_t *)r) != _mem_flag_used) {
-    return;
+  r-=SIZE_SIZE_T*3;
+  // try to merge siblings
+  size_t r_size = ((size_t*)r)[0];
+  while(1) {
+    if(r_size >= __root_size) {
+      // already the largest
+      break;
+    }
+    size_t sibling_block, sibling_block_next;
+    if((r - root + r_size) & r_size) {
+      // sibling on right
+      sibling_block = r + r_size;
+      sibling_block_next = ((size_t*)sibling_block)[1];
+      if(sibling_block_next == NULL) {
+        // sibling is in use, can't merge further
+        break;
+      }
+      _remove_block(sibling_block);
+      ((size_t*)r)[0] = r_size = r_size << 1;
+    } else {
+      // sibling on left
+      sibling_block = r - r_size;
+      sibling_block_next = ((size_t*)sibling_block)[1];
+      if(sibling_block_next == NULL) {
+        // sibling is in use, can't merge further
+        break;
+      }
+      _remove_block(sibling_block);
+      r = sibling_block;
+      ((size_t*)r)[0] = r_size = r_size << 1;
+    }
   }
-  // mark it as free
-  size_t flag = _mem_flag_free;
-  *((size_t *)r) = flag;
-  // calc ptr_tail
-  r-=_size_t_bytes;
-  n = *(size_t *)r; // size of current block
-  size_t ptr_tail = ((size_t)p)+n+_size_t_bytes;
-  // if not at tail return without moving __heap_tail
-  if (__heap_tail != ptr_tail) {
-    return;
-  }
-  __heap_tail = r;
-  while(r > (size_t)&__heap_base) {
-    r-=_size_t_bytes;
-    n = *(size_t *)r; // size of previous block
-    r-=n;
-    r-=_size_t_bytes;
-    flag = *((size_t *)r);
-    if (flag != _mem_flag_free) break;
-    r-=_size_t_bytes;
-    n = *(size_t *)r; // size of current block
-    __heap_tail = r;
-  }
-
+  // add block back to free list
+  _append_tail(r);
 }


### PR DESCRIPTION
I did a lot of testing in [the frame-test branch](https://github.com/evenifyouforget/fcsim/tree/frame-test) to find a minimal example that explodes (consumes infinity memory), and also verify that such a scenario still doesn't leak in `stl_test`.

I suspected the issue was `malloc` after all.

So I rewrote `malloc`.

After that, there was no increase in memory at all! The memory issue was fixed! So I concluded `malloc` was the problem. Sorry about your custom `malloc`, pawel. I didn't really bother to understand it, I just knew it was causing trouble somehow.

Unfortunately, with the new (correct) `malloc`, the max speed test was significantly slower.

| Initial root size | Minimum block size | Default vector size | Ticks per second (TPS) |
|-------------------|--------------------|---------------------|------------------------|
| 2^8               | 2^4                | 8                   | 11117.9                |
| 2^26              |                    |                     | 11602.4                |
| 2^29              |                    |                     | 10912.7                |
|                   | 2^8                |                     | 11490.6                |
|                   |                    | 24                  | 10929.4                |
|                   |                    | 32                  | 11395.0                |
| 2^29              | 2^8                | 32                  | 11054.4                |
|                   |                    |                     | 11559.2                |

Any cells left blank are the same as the first row.

If you recall, we're supposed to be getting 90k TPS here! Perhaps eating infinity memory really allows you to go fast. But I can't allow infinity memory, so we will have to settle for a correct `malloc` that might be slowing us down.

I tried some alternate parameters. Using a larger initial block size (arena) seemed to be making the game faster. So did using a larger minimum block size. And a larger default vector size. Maybe the infinity free memory thing is real after all.

Curiously, a non-power-of-2 default vector size didn't do better, even though my `malloc` is poorly optimized for powers of 2.

I tried combining the best settings, but it didn't end up faster.

I tried doing the default settings again, and got a different result.

In the end, I wasn't able to verify anything about the speed.

If I can't optimize for speed, I will optimize for memory - and that means keeping the rather small default values.

The game now uses around 16 MB of memory, which is more than before - around 8 MB before it starts leaking all over the place. But hey, at least it stays at 16 MB and will never use more.