### PR TITLE
Make code C compliant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ stl_test
 tags
 .ninja_log
 .ninja_deps
+.vscode


### PR DESCRIPTION
A user reported a build portability problem. Normally we solve this with docker, but... I don't feel like setting it up right now.

In the meantime, I'm fixing the file that appears to be the source of their build errors. Which is my `malloc.c` that is apparently not actually standard compliant. I have tested with `-Wall -Wextra -Wpedantic -Werror` and it seems to be fine.

Please report any additional errors you need fixing!