### PR TITLE
Loopmaster Contest

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -267,7 +267,7 @@ void tick_func(void *arg)
 		if(arena->single_ticks_remaining > 0)arena->single_ticks_remaining--;
 		step(arena->world);
 		arena->tick++;
-		if (!arena->has_won && goal_blocks_inside_goal_area(&arena)) {
+		if (!arena->has_won && goal_blocks_inside_goal_area(arena)) {
 			arena->has_won = true;
 			arena->tick_solve = arena->tick;
 			if(arena->autostop_on_solve) {

--- a/src/arena.c
+++ b/src/arena.c
@@ -241,12 +241,11 @@ static bool goal_blocks_inside_goal_area(struct arena *ar)
 			// loop contest logic
 			if(ar->tick == 1) {
 				ar->goal_piece_turns = 0; // reset. will be computed correctly the next frame
-			} else if(ar->tick <= 10000000) {
-				// stop updating after 10 million ticks
-				const double tau = 6.283185307179586;
+			} else if(ar->tick <= LOOP_CONTEST_END_TICKS) {
+				// stop updating after tick limit
 				// in general, this code is safe, but would calculate incorrectly if there are multiple goal pieces
 				double mod_angle = fp_atan2(block->body->m_position.x, block->body->m_position.y);
-				double mod_turns = mod_angle / tau;
+				double mod_turns = mod_angle / TAU;
 				ar->goal_piece_turns = mod_turns + rint(ar->goal_piece_turns - mod_turns);
 			}
 			any = true;

--- a/src/arena.c
+++ b/src/arena.c
@@ -245,7 +245,7 @@ static bool goal_blocks_inside_goal_area(struct arena *ar)
 				// stop updating after 10 million ticks
 				const double tau = 6.283185307179586;
 				// in general, this code is safe, but would calculate incorrectly if there are multiple goal pieces
-				double mod_angle = fp_atan2(block->shape.circ.y, block->shape.circ.x);
+				double mod_angle = fp_atan2(block->body->m_position.x, block->body->m_position.y);
 				double mod_turns = mod_angle / tau;
 				ar->goal_piece_turns = mod_turns + rint(ar->goal_piece_turns - mod_turns);
 			}

--- a/src/arena.c
+++ b/src/arena.c
@@ -247,7 +247,7 @@ static bool goal_blocks_inside_goal_area(struct arena *ar)
 				// in general, this code is safe, but would calculate incorrectly if there are multiple goal pieces
 				double mod_angle = fp_atan2(block->shape.circ.y, block->shape.circ.x);
 				double mod_turns = mod_angle / tau;
-				ar->goal_piece_turns = mod_turns + rint(mod_turns - ar->goal_piece_turns);
+				ar->goal_piece_turns = mod_turns + rint(ar->goal_piece_turns - mod_turns);
 			}
 			any = true;
 			if (!block_inside_area(block, &design->goal_area))

--- a/src/arena.h
+++ b/src/arena.h
@@ -103,6 +103,9 @@ struct arena {
 	// ui button templates
 	void* ui_buttons; // actual type: ui_button_collection*
 	bool ui_toolbar_opened;
+
+	// loop contest
+	double goal_piece_turns;
 };
 
 bool arena_compile_shaders(void);

--- a/src/arena.h
+++ b/src/arena.h
@@ -13,12 +13,14 @@
 
 #define TAU 6.28318530718
 
+#define LOOP_CONTEST_END_TICKS 100000
+
 struct view {
 	float x;
 	float y;
 	float scale;
 	float width;
-	float height;
+	float height; // loop_contest_end_ticks
 };
 
 enum state {

--- a/src/arena_graphics.cpp
+++ b/src/arena_graphics.cpp
@@ -687,6 +687,15 @@ void draw_tick_counter(struct arena *arena)
     x += FONT_X_INCREMENT * FONT_SCALE_DEFAULT * 1;
     x = draw_text_default(arena, std::to_string((int64_t)rint(graphics->tps_tracker.get_tps())), x, 10);
     x = draw_text_default(arena, "TPS", x, 10, 1);
+    // loop contest display
+    double turns = std::abs(arena->goal_piece_turns);
+    double predicted_turns = turns / std::max<uint64_t>(std::min<uint64_t>(arena->tick, 10000000), 1) * 10000000;
+    x += FONT_X_INCREMENT * FONT_SCALE_DEFAULT * 1;
+    x = draw_text_default(arena, std::to_string((int64_t)turns), x, 10, (arena->tick > 10000000 ? 4 : 2));
+    x = draw_text_default(arena, "revolutions", x, 10, 1);
+    x += FONT_X_INCREMENT * FONT_SCALE_DEFAULT * 1;
+    x = draw_text_default(arena, std::to_string((int64_t)predicted_turns), x, 10);
+    x = draw_text_default(arena, "predicted", x, 10, 1);
 }
 
 void draw_ui(arena* arena) {

--- a/src/arena_graphics.cpp
+++ b/src/arena_graphics.cpp
@@ -688,10 +688,10 @@ void draw_tick_counter(struct arena *arena)
     x = draw_text_default(arena, std::to_string((int64_t)rint(graphics->tps_tracker.get_tps())), x, 10);
     x = draw_text_default(arena, "TPS", x, 10, 1);
     // loop contest display
-    double turns = std::abs(arena->goal_piece_turns);
-    double predicted_turns = turns / std::max<uint64_t>(std::min<uint64_t>(arena->tick, 10000000), 1) * 10000000;
+    const double turns = std::abs(arena->goal_piece_turns);
+    const double predicted_turns = turns / std::max<uint64_t>(std::min<uint64_t>(arena->tick, LOOP_CONTEST_END_TICKS), 1) * LOOP_CONTEST_END_TICKS;
     x += FONT_X_INCREMENT * FONT_SCALE_DEFAULT * 1;
-    x = draw_text_default(arena, std::to_string((int64_t)turns), x, 10, (arena->tick > 10000000 ? 4 : 2));
+    x = draw_text_default(arena, std::to_string((int64_t)turns), x, 10, (arena->tick > LOOP_CONTEST_END_TICKS ? 4 : 2));
     x = draw_text_default(arena, "revolutions", x, 10, 1);
     x += FONT_X_INCREMENT * FONT_SCALE_DEFAULT * 1;
     x = draw_text_default(arena, std::to_string((int64_t)predicted_turns), x, 10);


### PR DESCRIPTION
Don't actually merge this.

I implemented a revolutions counter, which roughly speaking, counts how many times the goal piece goes around the origin. (undefined behaviour if there's more goal pieces)

The counter also stops at 100k ticks, and there's a prediction counter that you can use to measure the "RPM".

This is intended to be deployed at a variant URL for use in a certain contest...