### PR TITLE
The 144Hz update

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -76,6 +76,9 @@ fpatan_defines = [
     "USE_FPATAN",
     ]
 
+common_ccflags = [
+    "-Werror=incompatible-pointer-types",
+    ]
 linux_ccflags = [
     "-O3",
     "-flto",
@@ -109,7 +112,7 @@ base_env = Environment(
     )
 
 linux_env = base_env.Clone(
-    CCFLAGS = linux_ccflags,
+    CCFLAGS = common_ccflags + linux_ccflags,
     CPPPATH = common_include,
     # if using CCPDEFINES, need to match for fpatan variant
     LIBS = libs
@@ -117,14 +120,14 @@ linux_env = base_env.Clone(
 linux_env.VariantDir("build/linux", ".", False)
 
 test_env = base_env.Clone(
-    CCFLAGS = test_ccflags,
+    CCFLAGS = common_ccflags + test_ccflags,
     CPPPATH = common_include + wasm_include,
     CPPDEFINES = test_defines
     )
 test_env.VariantDir("build/test", ".", False)
 
 wasm_env = base_env.Clone(
-    CCFLAGS = wasm_ccflags,
+    CCFLAGS = common_ccflags + wasm_ccflags,
     CPPPATH = common_include + wasm_include,
     CC = 'clang',
     CXX = 'clang++',

--- a/SConstruct
+++ b/SConstruct
@@ -76,9 +76,22 @@ fpatan_defines = [
     "USE_FPATAN",
     ]
 
-common_ccflags = [
+werror_ccflags = [
+    # actually caught an error originally in loop-contest
     "-Werror=incompatible-pointer-types",
+    # preemptively catch some other common errors
+    "-Werror=uninitialized",
+    "-Werror=maybe-uninitialized",
+    "-Werror=return-type",
+    "-Werror=implicit-function-declaration",
+    "-Werror=sign-compare",
+    "-Werror=format",
+    "-Werror=int-conversion",
+    "-Werror=pointer-sign",
+    "-Werror=strict-aliasing",
+    "-Werror=unused-variable",
     ]
+common_ccflags = werror_ccflags
 linux_ccflags = [
     "-O3",
     "-flto",

--- a/devtool/find_unused_warnings.py
+++ b/devtool/find_unused_warnings.py
@@ -1,0 +1,180 @@
+"""
+Warnings taken from https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
+Runs `scons` to find out what is actually warning.
+Print a list of all warnings that we didn't trigger.
+"""
+
+import argparse
+import logging
+import re
+import subprocess
+
+gcc_wpedantic = [
+    "-Wattributes",
+    "-Wchanges-meaning",
+    "-Wcomma-subscript",
+    "-Wdeclaration-after-statement",
+    "-Welaborated-enum-base",
+    "-Wimplicit-int",
+    "-Wimplicit-function-declaration",
+    "-Wincompatible-pointer-types",
+    "-Wint-conversion",
+    "-Wlong-long",
+    "-Wmain",
+    "-Wnarrowing",
+    "-Wpointer-arith",
+    "-Wpointer-sign",
+    "-Wincompatible-pointer-types",
+    "-Wregister",
+    "-Wvla",
+    "-Wwrite-strings",
+    ]
+gcc_wall = [
+    "-Waddress",
+    "-Waligned-new",
+    "-Warray-bounds=1",
+    "-Warray-compare",
+    "-Warray-parameter=2",
+    "-Wbool-compare",
+    "-Wbool-operation",
+    "-Wc++11-compat",
+    "-Wc++14-compat",
+    "-Wc++17compat",
+    "-Wc++20compat",
+    "-Wcatch-value",
+    "-Wchar-subscripts",
+    "-Wclass-memaccess",
+    "-Wcomment",
+    "-Wdangling-else",
+    "-Wdangling-pointer=2",
+    "-Wdelete-non-virtual-dtor",
+    "-Wduplicate-decl-specifier",
+    "-Wenum-compare",
+    "-Wenum-int-mismatch",
+    "-Wformat=1",
+    "-Wformat-contains-nul",
+    "-Wformat-diag",
+    "-Wformat-extra-args",
+    "-Wformat-overflow=1",
+    "-Wformat-truncation=1",
+    "-Wformat-zero-length",
+    "-Wframe-address",
+    "-Wimplicit",
+    "-Wimplicit-function-declaration",
+    "-Wimplicit-int",
+    "-Winfinite-recursion",
+    "-Winit-self",
+    "-Wint-in-bool-context",
+    "-Wlogical-not-parentheses",
+    "-Wmain",
+    "-Wmaybe-uninitialized",
+    "-Wmemset-elt-size",
+    "-Wmemset-transposed-args",
+    "-Wmisleading-indentation",
+    "-Wmismatched-dealloc",
+    "-Wmismatched-new-delete",
+    "-Wmissing-attributes",
+    "-Wmissing-braces",
+    "-Wmultistatement-macros",
+    "-Wnarrowing",
+    "-Wnonnull",
+    "-Wnonnull-compare",
+    "-Wopenmp-simd",
+    "-Woverloaded-virtual=1",
+    "-Wpacked-not-aligned",
+    "-Wparentheses",
+    "-Wpessimizing-move",
+    "-Wpointer-sign",
+    "-Wrange-loop-construct",
+    "-Wreorder",
+    "-Wrestrict",
+    "-Wreturn-type",
+    "-Wself-move",
+    "-Wsequence-point",
+    "-Wsign-compare",
+    "-Wsizeof-array-div",
+    "-Wsizeof-pointer-div",
+    "-Wsizeof-pointer-memaccess",
+    "-Wstrict-aliasing",
+    "-Wstrict-overflow=1",
+    "-Wswitch",
+    "-Wtautological-compare",
+    "-Wtrigraphs",
+    "-Wuninitialized",
+    "-Wunknown-pragmas",
+    "-Wunused",
+    "-Wunused-but-set-variable",
+    "-Wunused-const-variable=1",
+    "-Wunused-function",
+    "-Wunused-label",
+    "-Wunused-local-typedefs",
+    "-Wunused-value",
+    "-Wunused-variable",
+    "-Wuse-after-free=2",
+    "-Wvla-parameter",
+    "-Wvolatile-register-var",
+    "-Wzero-length-bounds",
+    ]
+gcc_wextra = [
+    "-Wabsolute-value",
+    "-Walloc-size",
+    "-Wcalloc-transposed-args",
+    "-Wcast-function-type",
+    "-Wclobbered",
+    "-Wdangling-reference",
+    "-Wdeprecated-copy",
+    "-Wempty-body",
+    "-Wenum-conversion",
+    "-Wexpansion-to-defined",
+    "-Wignored-qualifiers",
+    "-Wimplicit-fallthrough=3",
+    "-Wmaybe-uninitialized",
+    "-Wmissing-field-initializers",
+    "-Wmissing-parameter-name",
+    "-Wmissing-parameter-type",
+    "-Wold-style-declaration",
+    "-Woverride-init",
+    "-Wredundant-move",
+    "-Wshift-negative-value",
+    "-Wsign-compare",
+    "-Wsized-deallocation",
+    "-Wstring-compare",
+    "-Wtype-limits",
+    "-Wuninitialized",
+    "-Wunterminated-string-initialization",
+    "-Wunused-parameter",
+    "-Wunused-but-set-parameter",
+    ]
+all_warnings = set(gcc_wpedantic + gcc_wall + gcc_wextra)
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    # parse args
+    parser = argparse.ArgumentParser(
+                    prog='find_unused_warnings.py',
+                    description='Run scons and find warnings that are not triggered but exist in gcc')
+    parser.add_argument('-e', '--error', action='store_true', help="Print instead some Python code to make scons treat those warnings as errors")
+    args = parser.parse_args()
+    # run subprocess
+    subprocess.run(['scons', '-c'], text=True, capture_output=True)
+    proc = subprocess.run(['scons'], text=True, capture_output=True)
+    hit_warnings_all = re.findall('(.*?src.+?(-W[^\\s]+\\w).*)', proc.stderr)
+    hit_warnings = {match[1] for match in hit_warnings_all}
+    hit_warnings_dict = {match[1]: match[0] for match in hit_warnings_all}
+    missed_warnings = all_warnings - hit_warnings
+    # output
+    logging.info(f'{len(all_warnings)} total known warnings')
+    logging.info(f'{len(hit_warnings)} hit warnings')
+    logging.info(f'{len(missed_warnings)} missed warnings')
+    if not args.error:
+        print('\n'.join(sorted(missed_warnings)))
+    else:
+        for warning in sorted(all_warnings):
+            if warning not in hit_warnings:
+                print(f'    "-Werror={warning[2:]}",')
+            else:
+                print(f'# auto comment: build would fail with this: {hit_warnings_dict[warning]}')
+                print(f'#   "-Werror={warning[2:]}",')
+
+if __name__ == "__main__":
+    main()

--- a/html/main.js
+++ b/html/main.js
@@ -325,6 +325,7 @@ function to_key(code)
 	if (code == "Digit7") return 16;
 	if (code == "Digit8") return 17;
 	if (code == "Digit9") return 18;
+	if (code == "Digit0") return 19;
 	if (code == "ShiftLeft") return 50;
 	if (code == "ControlLeft") return 37;
 	return 0;

--- a/html/main.js
+++ b/html/main.js
@@ -3,6 +3,13 @@
 const FC_URL = "https://fantasticcontraption.com";
 const SELF_URL = "";
 
+function self_url_full() {
+	// https://stackoverflow.com/a/6257480
+	// ends in /
+	// no query parameters
+	return location.protocol + '//' + location.host + location.pathname;
+}
+
 let play_button  = document.getElementById("play");
 let save_button  = document.getElementById("save");
 let save_menu    = document.getElementById("save_menu");
@@ -388,7 +395,7 @@ function alloc_str(str)
 function on_text(text)
 {
 	console.log(text);
-	design_link.innerHTML = "fcsim.com/?designId=" + text;
+	design_link.innerHTML = self_url_full() + "?designId=" + text;
 	design_link.style.display = "block";
 }
 

--- a/include/box2d/b2Math.h
+++ b/include/box2d/b2Math.h
@@ -28,6 +28,11 @@
 
 #define MIN_VALUE 5e-324
 
+#ifndef NAN
+// https://stackoverflow.com/a/7212363
+#define NAN (0.0 / 0.0)
+#endif
+
 inline bool b2IsValid(float64 x)
 {
 #ifdef _MSC_VER

--- a/src/arena.c
+++ b/src/arena.c
@@ -757,7 +757,6 @@ void update_wheel_joints2(struct wheel *wheel)
 		3.141592653589793,
 		4.71238898038469,
 	};
-	double spoke_x, spoke_y;
 	double x, y;
 	int i;
 

--- a/src/arena.c
+++ b/src/arena.c
@@ -294,9 +294,10 @@ void change_speed(struct arena *arena, int ms, int multiply)
 	}
 }
 
-double _fcsim_speed_factor = 1;
+double _fcsim_speed_factor = 2;
 int _fcsim_base_fps_mod = 0;
 int _fcsim_base_fps_table[] = BASE_FPS_TABLE;
+double _fcsim_target_tps = 60;
 void change_speed_factor(struct arena *arena, double new_factor, int new_base_fps_mod) {
 	// only change values if not given NO_CHANGE
 	if(new_factor != NO_CHANGE) {
@@ -309,6 +310,7 @@ void change_speed_factor(struct arena *arena, double new_factor, int new_base_fp
 	double factor = _fcsim_speed_factor;
 	int base_fps = _fcsim_base_fps_table[_fcsim_base_fps_mod];
 	if(factor < 1)factor = 1;
+	_fcsim_target_tps = factor * base_fps;
 	double mspt = 1000 / (base_fps * factor);
 	long long int multiples = 1 + (long long int)(MIN_MSPT / mspt);
 	long long int mspt_int = (long long int)(1000 * multiples / (base_fps * factor));

--- a/src/arena.c
+++ b/src/arena.c
@@ -6,6 +6,7 @@
 #include <box2d/b2World.h>
 #include <box2d/b2CMath.h>
 
+#define ARENA_C
 #include "gl.h"
 #include "xml.h"
 #include "interval.h"
@@ -415,7 +416,7 @@ void arena_key_down_event(struct arena *arena, int key)
 		break;
 	case 18: /* 9 */
 		// maximum hyperspeed
-		change_speed_factor(arena, 1e9, NO_CHANGE);
+		change_speed_factor(arena, 1e12, NO_CHANGE);
 		break;
 	case 19: /* 0 */
 		// cycle base speeds

--- a/src/arena.c
+++ b/src/arena.c
@@ -294,11 +294,24 @@ void change_speed(struct arena *arena, int ms, int multiply)
 	}
 }
 
-void change_speed_factor(struct arena *arena, double factor) {
+double _fcsim_speed_factor = 1;
+int _fcsim_base_fps_mod = 0;
+int _fcsim_base_fps_table[] = BASE_FPS_TABLE;
+void change_speed_factor(struct arena *arena, double new_factor, int new_base_fps_mod) {
+	// only change values if not given NO_CHANGE
+	if(new_factor != NO_CHANGE) {
+		_fcsim_speed_factor = new_factor;
+	}
+	if(new_base_fps_mod != NO_CHANGE) {
+		_fcsim_base_fps_mod = new_base_fps_mod;
+	}
+	// calculate new speed factor
+	double factor = _fcsim_speed_factor;
+	int base_fps = _fcsim_base_fps_table[_fcsim_base_fps_mod];
 	if(factor < 1)factor = 1;
-	double mspt = 1000 / (BASE_FPS * factor);
+	double mspt = 1000 / (base_fps * factor);
 	long long int multiples = 1 + (long long int)(MIN_MSPT / mspt);
-	long long int mspt_int = (long long int)(1000 * multiples / (BASE_FPS * factor));
+	long long int mspt_int = (long long int)(1000 * multiples / (base_fps * factor));
 	change_speed(arena, (int)mspt_int, (int)multiples);
 }
 
@@ -375,31 +388,36 @@ void arena_key_down_event(struct arena *arena, int key)
 		arena->tool_hidden = TOOL_CCW_WHEEL;
 		break;
 	case 10: /* 1 */
-		change_speed_factor(arena, 1);
+		change_speed_factor(arena, 1, NO_CHANGE);
 		break;
 	case 11: /* 2 */
-		change_speed_factor(arena, 2);
+		change_speed_factor(arena, 2, NO_CHANGE);
 		break;
 	case 12: /* 3 */
-		change_speed_factor(arena, 4);
+		change_speed_factor(arena, 4, NO_CHANGE);
 		break;
 	case 13: /* 4 */
-		change_speed_factor(arena, 8);
+		change_speed_factor(arena, 8, NO_CHANGE);
 		break;
 	case 14: /* 5 */
-		change_speed_factor(arena, 100);
+		change_speed_factor(arena, 100, NO_CHANGE);
 		break;
 	case 15: /* 6 */
-		change_speed_factor(arena, 1e3);
+		change_speed_factor(arena, 1e3, NO_CHANGE);
 		break;
 	case 16: /* 7 */
-		change_speed_factor(arena, 1e4);
+		change_speed_factor(arena, 1e4, NO_CHANGE);
 		break;
 	case 17: /* 8 */
-		change_speed_factor(arena, 1e5);
+		change_speed_factor(arena, 1e5, NO_CHANGE);
 		break;
 	case 18: /* 9 */
-		change_speed_factor(arena, 1e9);
+		// maximum hyperspeed
+		change_speed_factor(arena, 1e9, NO_CHANGE);
+		break;
+	case 19: /* 0 */
+		// cycle base speeds
+		change_speed_factor(arena, NO_CHANGE, (_fcsim_base_fps_mod + 1) % BASE_FPS_TABLE_SIZE);
 		break;
 	case 50: /* shift */
 		arena->shift = true;

--- a/src/arena.h
+++ b/src/arena.h
@@ -105,6 +105,7 @@ struct arena {
 	// ui button templates
 	void* ui_buttons; // actual type: ui_button_collection*
 	bool ui_toolbar_opened;
+	bool ui_speedbar_opened;
 };
 
 bool arena_compile_shaders(void);
@@ -138,6 +139,10 @@ extern GLuint joint_program_coord_attrib;
 
 // c++ compat
 void block_graphics_init(struct arena *ar);
+#ifndef ARENA_C
+extern int _fcsim_base_fps_mod;
 extern double _fcsim_target_tps;
+#endif
+void change_speed_factor(struct arena *arena, double new_factor, int new_base_fps_mod);
 
 #endif

--- a/src/arena.h
+++ b/src/arena.h
@@ -4,7 +4,9 @@
 #include "graph.h"
 #include "text.h"
 
-#define BASE_FPS 30
+#define NO_CHANGE -1
+#define BASE_FPS_TABLE {30, 36}
+#define BASE_FPS_TABLE_SIZE 2
 #ifdef __wasm__
 #define MIN_MSPT 33
 #else

--- a/src/arena.h
+++ b/src/arena.h
@@ -138,5 +138,6 @@ extern GLuint joint_program_coord_attrib;
 
 // c++ compat
 void block_graphics_init(struct arena *ar);
+extern double _fcsim_target_tps;
 
 #endif

--- a/src/arena_graphics.cpp
+++ b/src/arena_graphics.cpp
@@ -564,6 +564,42 @@ void on_button_clicked(arena* arena, ui_button_single& button) {
     if(button.id == ui_button_id{2, 3}) {
         arena->single_ticks_remaining = 1;
     }
+    if(button.id == ui_button_id{3, 0}) {
+        arena->ui_speedbar_opened = true;
+    }
+    if(button.id == ui_button_id{4, 1}) {
+        arena->ui_speedbar_opened = false;
+    }
+    if(button.id == ui_button_id{4, 2}) {
+        change_speed_factor(arena, 1, NO_CHANGE);
+    }
+    if(button.id == ui_button_id{4, 3}) {
+        change_speed_factor(arena, 2, NO_CHANGE);
+    }
+    if(button.id == ui_button_id{4, 4}) {
+        change_speed_factor(arena, 4, NO_CHANGE);
+    }
+    if(button.id == ui_button_id{4, 5}) {
+        change_speed_factor(arena, 8, NO_CHANGE);
+    }
+    if(button.id == ui_button_id{4, 6}) {
+        change_speed_factor(arena, 100, NO_CHANGE);
+    }
+    if(button.id == ui_button_id{4, 7}) {
+        change_speed_factor(arena, 1e3, NO_CHANGE);
+    }
+    if(button.id == ui_button_id{4, 8}) {
+        change_speed_factor(arena, 1e4, NO_CHANGE);
+    }
+    if(button.id == ui_button_id{4, 9}) {
+        change_speed_factor(arena, 1e5, NO_CHANGE);
+    }
+    if(button.id == ui_button_id{4, 10}) {
+        change_speed_factor(arena, 1e12, NO_CHANGE);
+    }
+    if(button.id == ui_button_id{4, 11}) {
+        change_speed_factor(arena, NO_CHANGE, (_fcsim_base_fps_mod + 1) % BASE_FPS_TABLE_SIZE);
+    }
 }
 
 void regenerate_ui_buttons(arena* arena) {
@@ -660,6 +696,97 @@ void regenerate_ui_buttons(arena* arena) {
         button.texts.push_back(ui_button_text{"Step", 1});
         all_buttons->buttons.push_back(button);
     }
+
+    float top_bar_x_offset = -50 + (!arena->ui_toolbar_opened?90:484);
+
+    {
+        ui_button_single button{{3, 0}, top_bar_x_offset + 75, vh, 30, 30};
+        button.enabled = !arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"v", 2});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 0}, top_bar_x_offset + 120 + 55 * 4.5f, vh, 60 + 55 * 9 + 8, 128};
+        button.enabled = arena->ui_speedbar_opened;
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 1}, top_bar_x_offset + 75, vh, 30, 128, 2};
+        button.enabled = arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"^", 2, 0, -30});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 2}, top_bar_x_offset + 120, vh - 30, 50, 50, 2};
+        button.enabled = arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"1", 2, 0, 5});
+        button.texts.push_back(ui_button_text{"1x", 1, 0, -10});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 3}, top_bar_x_offset + 120 + 55, vh - 30, 50, 50, 2};
+        button.enabled = arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"2", 2, 0, 5});
+        button.texts.push_back(ui_button_text{"2x", 1, 0, -10});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 4}, top_bar_x_offset + 120 + 55 * 2, vh - 30, 50, 50, 2};
+        button.enabled = arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"3", 2, 0, 5});
+        button.texts.push_back(ui_button_text{"4x", 1, 0, -10});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 5}, top_bar_x_offset + 120 + 55 * 3, vh - 30, 50, 50, 2};
+        button.enabled = arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"4", 2, 0, 5});
+        button.texts.push_back(ui_button_text{"8x", 1, 0, -10});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 6}, top_bar_x_offset + 120 + 55 * 4, vh - 30, 50, 50, 2};
+        button.enabled = arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"5", 2, 0, 5});
+        button.texts.push_back(ui_button_text{"100x", 1, 0, -10});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 7}, top_bar_x_offset + 120 + 55 * 5, vh - 30, 50, 50, 2};
+        button.enabled = arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"6", 2, 0, 5});
+        button.texts.push_back(ui_button_text{"1000x", 1, 0, -10});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 8}, top_bar_x_offset + 120 + 55 * 6, vh - 30, 50, 50, 2};
+        button.enabled = arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"7", 2, 0, 5});
+        button.texts.push_back(ui_button_text{"10000x", 1, 0, -10});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 9}, top_bar_x_offset + 120 + 55 * 7, vh - 30, 50, 50, 2};
+        button.enabled = arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"8", 2, 0, 5});
+        button.texts.push_back(ui_button_text{"100000x", 1, 0, -10});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 10}, top_bar_x_offset + 120 + 55 * 8, vh - 30, 50, 50, 2};
+        button.enabled = arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"9", 2, 0, 5});
+        button.texts.push_back(ui_button_text{"MAX", 1, 0, -10});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{4, 11}, top_bar_x_offset + 120 + 55 * 9, vh - 30, 50, 50, 2};
+        button.enabled = arena->ui_speedbar_opened;
+        button.texts.push_back(ui_button_text{"0", 2, 0, 10});
+        button.texts.push_back(ui_button_text{"Change", 1, 0, -5});
+        button.texts.push_back(ui_button_text{"base TPS", 1, 0, -15});
+        all_buttons->buttons.push_back(button);
+    }
 }
 
 // Draw text, and return the x where the text ends
@@ -706,7 +833,7 @@ void draw_tick_counter(struct arena *arena)
     x = draw_text_default(arena, "FPS", x, 10, 1);
     x = std::max(x, 10 + FONT_X_INCREMENT * FONT_SCALE_DEFAULT * 8);
     x += FONT_X_INCREMENT * FONT_SCALE_DEFAULT * 1;
-    x = draw_text_default(arena, std::to_string((int64_t)rint(tps_value)), x, 10);
+    x = draw_text_default(arena, tps_value >= 1e12?"Infinity":std::to_string((int64_t)rint(tps_value)), x, 10);
     x = draw_text_default(arena, !tps_is_prediction?"TPS average":"TPS predicted", x, 10, 1);
 }
 

--- a/src/arena_graphics.cpp
+++ b/src/arena_graphics.cpp
@@ -137,7 +137,7 @@ uint16_t block_graphics_layer::push_vertex(float x, float y, color col) {
 }
 
 void block_graphics::ensure_layer(int z_offset) {
-    while(layers.size() <= z_offset) {
+    while((int)layers.size() <= z_offset) {
         layers.emplace_back();
     }
 }
@@ -290,7 +290,6 @@ static void block_graphics_add_rect_single(struct block_graphics *graphics,
 	float ws = w * sina_half;
 	float hc = h * cosa_half;
 	float hs = h * sina_half;
-	int i;
 
     uint16_t v1 = graphics->push_vertex(shell.x + wc - hs, shell.y + ws + hc, col, z_offset);
     uint16_t v2 = graphics->push_vertex(shell.x - wc - hs, shell.y - ws + hc, col, z_offset);
@@ -563,7 +562,7 @@ void regenerate_ui_buttons(arena* arena) {
     ui_button_collection* all_buttons = (ui_button_collection*)arena->ui_buttons;
     all_buttons->buttons.clear();
 
-    float vw = arena->view.width;
+    //float vw = arena->view.width;
     float vh = arena->view.height;
 
     {

--- a/src/box2d/b2CollidePoly.cpp
+++ b/src/box2d/b2CollidePoly.cpp
@@ -291,7 +291,6 @@ void b2CollidePoly(b2Manifold* manifold, const b2PolyShape* polyA, const b2PolyS
 	b2Vec2 v11 = vert1s[edge1];
 	b2Vec2 v12 = edge1 + 1 < count1 ? vert1s[edge1+1] : vert1s[0];
 
-	b2Vec2 dv = v12 - v11;
 	b2Vec2 sideNormal = b2Mul(poly1->m_shape.m_R, v12 - v11);
 	float64 sideNormalLenInv = 1.0 / b2Vec2_Length(&sideNormal);
 	sideNormal.x *= sideNormalLenInv;

--- a/src/box2d/b2ContactSolver.cpp
+++ b/src/box2d/b2ContactSolver.cpp
@@ -73,8 +73,7 @@ void b2ContactSolver_ctor(b2ContactSolver *solver, b2Contact** contacts, int32 c
 				ccp->normalImpulse = cp->normalImpulse;
 				ccp->tangentImpulse = cp->tangentImpulse;
 				ccp->separation = cp->separation;
-				unsigned long long dupa = 0x7fffffffe0000000LLU;
-				ccp->positionImpulse = *(double *)&dupa;
+				ccp->positionImpulse = NAN;
 
 				b2Vec2 r1 = cp->position - b1->m_position;
 				b2Vec2 r2 = cp->position - b2->m_position;
@@ -263,7 +262,6 @@ bool b2ContactSolver_SolvePositionConstraints(b2ContactSolver *solver, float64 b
 		float64 invMass2 = b2->m_invMass;
 		float64 invI2 = b2->m_invI;
 		b2Vec2 normal = c->normal;
-		b2Vec2 tangent = b2Cross(normal, 1.0);
 
 		// Solver normal constraints
 		for (int32 j = 0; j < c->pointCount; ++j)

--- a/src/export.c
+++ b/src/export.c
@@ -37,7 +37,7 @@ void dtostr_frac(char *buf, double val)
 {
 	uint8_t tmp[18];
 	uint64_t u;
-	int l;
+	int l = 0;
 	int i;
 
 	u = val * 1e18;
@@ -49,7 +49,7 @@ void dtostr_frac(char *buf, double val)
 		u /= 10;
 	}
 
-	for (i = 0; i < 18; i++) {
+	for (i = 0; i < 18; i++) { // compiler says remove the condition if it is always true
 		if (tmp[i] != 0) {
 			l = i;
 			break;

--- a/src/fpmath/atan2.c
+++ b/src/fpmath/atan2.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
 #include <fpmath/fpmath.h>
@@ -44,19 +45,7 @@ typedef union { int4 i[2]; double x; double d; } mynumber;
 /**/ d11            = {{0x22b13c25, 0xbfb74580} }, /* -0.090... */
 /**/ d13            = {{0x8b31cbce, 0x3fb375f0} }, /*  0.076... */
   /* polynomial II */
-/**/ f3             = {{0x55555555, 0xbfd55555} }, /* -1/3      */
-/**/ ff3            = {{0x55555555, 0xbc755555} }, /* -1/3-f3   */
-/**/ f5             = {{0x9999999a, 0x3fc99999} }, /*  1/5      */
-/**/ ff5            = {{0x9999999a, 0xbc699999} }, /*  1/5-f5   */
-/**/ f7             = {{0x92492492, 0xbfc24924} }, /* -1/7      */
-/**/ ff7            = {{0x92492492, 0xbc624924} }, /* -1/7-f7   */
-/**/ f9             = {{0x1c71c71c, 0x3fbc71c7} }, /*  1/9      */
-/**/ ff9            = {{0x1c71c71c, 0x3c5c71c7} }, /*  1/9-f9   */
-/**/ f11            = {{0x745d1746, 0xbfb745d1} }, /* -1/11     */
-/**/ f13            = {{0x13b13b14, 0x3fb3b13b} }, /*  1/13     */
-/**/ f15            = {{0x11111111, 0xbfb11111} }, /* -1/15     */
-/**/ f17            = {{0x1e1e1e1e, 0x3fae1e1e} }, /*  1/17     */
-/**/ f19            = {{0xbca1af28, 0xbfaaf286} }, /* -1/19     */
+// all were unused. removed
   /* constants    */
 /**/ inv16          = {{0x00000000, 0x3fb00000} }, /*  1/16         */
 /**/ opi            = {{0x54442d18, 0x400921fb} }, /*  pi           */
@@ -69,28 +58,6 @@ typedef union { int4 i[2]; double x; double d; } mynumber;
 /**/ mqpi           = {{0x54442d18, 0xbfe921fb} }, /* -pi/4         */
 /**/ tqpi           = {{0x7f3321d2, 0x4002d97c} }, /*  3pi/4        */
 /**/ mtqpi          = {{0x7f3321d2, 0xc002d97c} }, /* -3pi/4        */
-/**/ u1             = {{0x00000000, 0x3c314c2a} }, /*  9.377e-19    */
-/**/ u2             = {{0x00000000, 0x3bf955e4} }, /*  8.584e-20    */
-/**/ u3             = {{0x00000000, 0x3bf955e4} }, /*  8.584e-20    */
-/**/ u4             = {{0x00000000, 0x3bf955e4} }, /*  8.584e-20    */
-/**/ u5             = {{0x00000000, 0x3aaef2d1} }, /*  5e-26        */
-/**/ u6             = {{0x00000000, 0x3a6eeb36} }, /*  3.122e-27    */
-/**/ u7             = {{0x00000000, 0x3a6eeb36} }, /*  3.122e-27    */
-/**/ u8             = {{0x00000000, 0x3a6eeb36} }, /*  3.122e-27    */
-/**/ u91            = {{0x00000000, 0x3c6dffc0} }, /*  1.301e-17    */
-/**/ u92            = {{0x00000000, 0x3c527bd0} }, /*  4.008e-18    */
-/**/ u93            = {{0x00000000, 0x3c3cd057} }, /*  1.562e-18    */
-/**/ u94            = {{0x00000000, 0x3c329cdf} }, /*  1.009e-18    */
-/**/ ua1            = {{0x00000000, 0x3c3a1edf} }, /*  1.416e-18    */
-/**/ ua2            = {{0x00000000, 0x3c33f0e1} }, /*  1.081e-18    */
-/**/ ub             = {{0x00000000, 0x3a98c56d} }, /*  2.001e-26    */
-/**/ uc             = {{0x00000000, 0x3a9375de} }, /*  1.572e-26    */
-/**/ ud[MM]         ={{{0x00000000, 0x38c6eddf} }, /*  3.450e-35    */
-/**/                  {{0x00000000, 0x35c6ef60} }, /*  1.226e-49    */
-/**/                  {{0x00000000, 0x32c6ed2f} }, /*  4.354e-64    */
-/**/                  {{0x00000000, 0x23c6eee8} }, /*  2.465e-136   */
-/**/                  {{0x00000000, 0x11c6ed16} }},/*  4.955e-223   */
-/**/ ue             = {{0x00000000, 0x38900e9d} }, /*  3.02e-36     */
 /**/ two500         = {{0x00000000, 0x5f300000} }, /*  2**500       */
 /**/ twom500        = {{0x00000000, 0x20b00000} }; /*  2**(-500)    */
 
@@ -1817,9 +1784,9 @@ double fp_atan2(double y, double x)
     }
 
   /* y=+-0 */
-  if (uy == 0x00000000)
+  if ((uint32_t)uy == 0x00000000)
     {
-      if (dy == 0x00000000)
+      if ((uint32_t)dy == 0x00000000)
 	{
 	  if ((ux & 0x80000000) == 0x00000000)
 	    return 0;
@@ -1827,9 +1794,9 @@ double fp_atan2(double y, double x)
 	    return opi.d;
 	}
     }
-  else if (uy == 0x80000000)
+  else if ((uint32_t)uy == 0x80000000)
     {
-      if (dy == 0x00000000)
+      if ((uint32_t)dy == 0x00000000)
 	{
 	  if ((ux & 0x80000000) == 0x00000000)
 	    return -0.0;
@@ -1848,16 +1815,16 @@ double fp_atan2(double y, double x)
     }
 
   /* x=+-INF */
-  if (ux == 0x7ff00000)
+  if ((uint32_t)ux == 0x7ff00000)
     {
-      if (dx == 0x00000000)
+      if ((uint32_t)dx == 0x00000000)
 	{
-	  if (uy == 0x7ff00000)
+	  if ((uint32_t)uy == 0x7ff00000)
 	    {
 	      if (dy == 0x00000000)
 		return qpi.d;
 	    }
-	  else if (uy == 0xfff00000)
+	  else if ((uint32_t)uy == 0xfff00000)
 	    {
 	      if (dy == 0x00000000)
 		return mqpi.d;
@@ -1871,18 +1838,18 @@ double fp_atan2(double y, double x)
 	    }
 	}
     }
-  else if (ux == 0xfff00000)
+  else if ((uint32_t)ux == 0xfff00000)
     {
-      if (dx == 0x00000000)
+      if ((uint32_t)dx == 0x00000000)
 	{
-	  if (uy == 0x7ff00000)
+	  if ((uint32_t)uy == 0x7ff00000)
 	    {
-	      if (dy == 0x00000000)
+	      if ((uint32_t)dy == 0x00000000)
 		return tqpi.d;
 	    }
-	  else if (uy == 0xfff00000)
+	  else if ((uint32_t)uy == 0xfff00000)
 	    {
-	      if (dy == 0x00000000)
+	      if ((uint32_t)dy == 0x00000000)
 		return mtqpi.d;
 	    }
 	  else
@@ -1896,14 +1863,14 @@ double fp_atan2(double y, double x)
     }
 
   /* y=+-INF */
-  if (uy == 0x7ff00000)
+  if ((uint32_t)uy == 0x7ff00000)
     {
-      if (dy == 0x00000000)
+      if ((uint32_t)dy == 0x00000000)
 	return hpi.d;
     }
-  else if (uy == 0xfff00000)
+  else if ((uint32_t)uy == 0xfff00000)
     {
-      if (dy == 0x00000000)
+      if ((uint32_t)dy == 0x00000000)
 	return mhpi.d;
     }
 
@@ -1919,7 +1886,6 @@ double fp_atan2(double y, double x)
     {
       if (x > 0)
 	{
-	  double ret;
 	  z = ay / ax;
 	  return copysign (z, y);
 	}

--- a/src/graph.c
+++ b/src/graph.c
@@ -84,10 +84,6 @@ struct material water_rod_material = {
 	.collision_mask = WATER_COLLISION_MASK,
 };
 
-static float goal_r = 1.000f;
-static float goal_g = 0.400f;
-static float goal_b = 0.400f;
-
 static void init_block_list(struct block_list *list)
 {
 	list->head = NULL;

--- a/test/stl_test_main.cpp
+++ b/test/stl_test_main.cpp
@@ -17,7 +17,7 @@ int main() {
         for(int j = 0; j < i; ++j) {
             vec.push_back(j);
         }
-        assert(vec.size() == i);
+        assert(vec.size() == (size_t)i);
     }
     // test vector index
     for(int i = 0; i < 100; ++i) {
@@ -26,7 +26,7 @@ int main() {
             vec.push_back(j);
             assert(vec[j] == j);
         }
-        assert(vec.size() == i);
+        assert(vec.size() == (size_t)i);
     }
     // test vector clear
     for(int i = 0; i < 100; ++i) {
@@ -35,13 +35,13 @@ int main() {
             vec.push_back(j);
             assert(vec[j] == j);
         }
-        assert(vec.size() == i);
+        assert(vec.size() == (size_t)i);
         vec.clear();
         for(int j = 0; j < i; ++j) {
             vec.push_back(2 * j);
             assert(vec[j] == 2 * j);
         }
-        assert(vec.size() == i);
+        assert(vec.size() == (size_t)i);
     }
     // test string construct destruct
     {
@@ -142,7 +142,7 @@ int main() {
         assert(str.size() == 0);
         for(int i = 1; i < 10; ++i) {
             str.append('0' + i);
-            assert(str.size() == i);
+            assert(str.size() == (size_t)i);
         }
     }
     // test to_string 0


### PR DESCRIPTION
# Clean up

Since I was making C/C++ mistakes and didn't want to waste so much time debugging in the future, I added a bunch of `-Werror=` flags to the `SConstruct` file. This revealed a lot of unused variables, uninitialized variables, and other sketchy looking code that might be erroneous. I fixed the errors. If the process is correct, this should not change the actual function of the code in any way.

I also added a Python script to find warnings we don't trigger, with the idea that we could add them as `-Werror=` flags, so if future builds fail, we messed something up that wasn't already messed up. A kind of regression testing. Though I didn't end up using most of these missed warnings.

I considered doing `-Werror -Wall` etc. but after trying it and chasing down errors for a while, it seems there's a lot of non-compliance already going on, especially in box2d, and I don't feel confident to fully clean that codebase.

# TPS tracker changes

The TPS tracker behaves in a smarter more dynamic way now. It clears the buffer if the design isn't running, so old measurements don't cause erroneous display values. The sliding window size also adjusts based on measured FPS, aiming to average the TPS over the past 2 seconds or so. If the design isn't running, or there's not enough data, it shows a "predicted" TPS, which is the TPS we are trying to hit based on the current speed settings.

# New speed key: 0. Changes base TPS

Users with 144Hz monitors were complaining that the game looked choppy because the TPS clock was always set to a multiple of 30, which is clearly not a divisor of 144. So I added the ability to change the base TPS by pressing 0. Currently this just toggles between 30 and 36, but if we discover other users with some other refresh rate having a similar problem in the future, we can add another base TPS option.

If you want 144 TPS, try pressing 0 to set the base TPS to 36, and 3 to set the multiplier to 4x. This gives 144 TPS.

# Speed top bar

It always annoyed me that the speed keys existed, but there was no GUI indication of them. Now there's a speed bar next to the tool bar at the top, and it shows all the speed keys and what they do.

# Saving display

Always shows the current URL that you are on ex. `https://ft.jtai.dev/?designId=12483401` if you are playing on `https://ft.jtai.dev/`. Previously it was hardcoded as `http://fcsim.com/`