### PR TITLE
TPS Debugging

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -242,6 +242,7 @@ let gl_env = {
 	},
 
 	set_interval(func, delay, arg) {
+		console.log("Set clock to " + delay.toString() + " ms (expected " + (1000/delay).toString() + " Hz)");
 		return setInterval(inst.exports.call, delay, func, arg);
 	},
 

--- a/html/main.js
+++ b/html/main.js
@@ -91,6 +91,23 @@ function make_cstring(data)
 	return make_string(data, size);
 }
 
+function debugRealClockSpeed(delayMs) {
+	// Run a dummy function on a clock to see if the browser is ticking on an accurate clock
+	const targetNumTicks = 50;
+	const data = [undefined, -1, undefined]; // self handle, counter, first tick time
+	data[0] = setInterval(function(){
+		data[1] += 1;
+		if(data[1] === 0) {
+			data[2] = performance.now();
+		} else if(data[1] >= targetNumTicks && data[0]) {
+			clearInterval(data[0]);
+			const realDelayMs = (performance.now() - data[2]) / data[1];
+			const realTPS = 1000 / realDelayMs;
+			console.log("Real clock: " + realDelayMs.toString() + " ms (" + realTPS.toString() + " Hz) (" + data[1].toString() + " ticks sampled)");
+		}
+	}, delayMs);
+}
+
 let gl_env = {
 	glActiveTexture(texture) {
 		gl.activeTexture(texture);
@@ -243,6 +260,7 @@ let gl_env = {
 
 	set_interval(func, delay, arg) {
 		console.log("Set clock to " + delay.toString() + " ms (expected " + (1000/delay).toString() + " Hz)");
+		debugRealClockSpeed(delay);
 		return setInterval(inst.exports.call, delay, func, arg);
 	},
 

--- a/src/arena.h
+++ b/src/arena.h
@@ -8,7 +8,7 @@
 #define BASE_FPS_TABLE {30, 36}
 #define BASE_FPS_TABLE_SIZE 2
 #ifdef __wasm__
-#define MIN_MSPT 33
+#define MIN_MSPT 10
 #else
 #define MIN_MSPT 5
 #endif


### PR DESCRIPTION
Adds some JavaScript prints to show the intended clock and real (measured) clock every time the clock is changed using `setInterval`.

Also reduced the minimum MSPT from 33 to 10 to be nicer for high frequency displays.

There's still the issue that `setInterval` doesn't have any more precision than 1 ms, so we can't get exactly 30 TPS, or 60, or 144. In the future perhaps this will be addressed with a complete overhaul to the timing system which dynamically adjusts +/- 1 ms depending on whether the real clock is early or late, to correct for small amounts of drift and target a fractional MSPT.