### PR TITLE
Live memory estimate in bottom bar (web only)

### DIFF
--- a/arch/wasm/include/stdlib.h
+++ b/arch/wasm/include/stdlib.h
@@ -8,6 +8,10 @@ void *malloc(size_t size);
 void *calloc(size_t nmemb, size_t size);
 void free(void *ptr);
 
+// estimate the total memory used by wasm
+// the actual memory usage will be higher because the JS part is about 20 MB and not included
+size_t total_memory_used_bytes();
+
 #ifdef __cplusplus
 };
 #endif

--- a/src/arch/wasm/malloc.c
+++ b/src/arch/wasm/malloc.c
@@ -204,3 +204,8 @@ void free(void* p) {
   // add block back to free list
   _append_tail(r);
 }
+
+size_t total_memory_used_bytes() {
+  // each page is 64 KiB
+  return memory_size() << 16;
+}

--- a/src/arena_graphics.cpp
+++ b/src/arena_graphics.cpp
@@ -1,5 +1,6 @@
 #ifdef __wasm__
 #include "stdint.h"
+#include "stdlib.h"
 #include "stl_mock.h"
 #else
 #include <algorithm>
@@ -887,6 +888,13 @@ void draw_tick_counter(struct arena *arena)
     x += FONT_X_INCREMENT * FONT_SCALE_DEFAULT * 1;
     x = draw_text_default(arena, tps_value >= 1e9?"Infinity":std::to_string((int64_t)rint(tps_value)), x, 10);
     x = draw_text_default(arena, !tps_is_prediction?"TPS average":"TPS predicted", x, 10, 1);
+
+#ifdef __wasm__
+    // memory stats for web only
+    x += FONT_X_INCREMENT * FONT_SCALE_DEFAULT * 1;
+    x = draw_text_default(arena, std::to_string(total_memory_used_bytes() / 1000000), x, 10);
+    x = draw_text_default(arena, "MB", x, 10, 1);
+#endif
 }
 
 void draw_ui(arena* arena) {


### PR DESCRIPTION
New features for web:

* Function `total_memory_used_bytes()`
* Show the result at the bottom bar

The actual memory usage will be higher than what is displayed by about 20 MB. This is because of the JS part, which is not counted. We only count the memory pages wasm is using.

It should be helpful in the future to quickly spot memory leaks, and helpful to users so they know what optional feature (such as predicted trails) use a lot of memory.

For future reference, the current biggest consumer of memory seems to be box2d worlds: the number of worlds active explains most of the variation in memory usage. This was seen most with trajectory prediction and the autotweaker.