### PR TITLE
Lockout mode: if preview solves, prevent further changes

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -963,6 +963,10 @@ void update_move(struct arena *arena, double dx, double dy)
 
 void action_move(struct arena *arena, int x, int y)
 {
+	if(arena->lock_if_preview_solves && arena->preview_has_won) {
+		return;
+	}
+
 	float x_world;
 	float y_world;
 	float dx;
@@ -1061,6 +1065,10 @@ void adjust_new_rod(struct rod *rod)
 
 void action_new_rod(struct arena *arena, int x, int y)
 {
+	if(arena->lock_if_preview_solves && arena->preview_has_won) {
+		return;
+	}
+
 	struct rod *rod = &arena->new_block->shape.rod;
 	float x_world;
 	float y_world;
@@ -1098,6 +1106,10 @@ void action_new_rod(struct arena *arena, int x, int y)
 
 void action_new_wheel(struct arena *arena, int x, int y)
 {
+	if(arena->lock_if_preview_solves && arena->preview_has_won) {
+		return;
+	}
+
 	struct wheel *wheel = &arena->new_block->shape.wheel;
 	float x_world;
 	float y_world;

--- a/src/arena.c
+++ b/src/arena.c
@@ -184,6 +184,8 @@ void arena_init(struct arena *arena, float w, float h, char *xml, int len)
 	arena->preview_gp_trajectory = false;
 	arena->preview_design = NULL;
 	arena->preview_world = NULL;
+	arena->preview_has_won = false;
+	arena->lock_if_preview_solves = false;
 
 	change_speed_preset(arena, 2);
 }

--- a/src/arena.h
+++ b/src/arena.h
@@ -106,6 +106,8 @@ struct arena {
 	struct design* preview_design;
 	b2World *preview_world;
 	void *preview_trail; // real type: multi_trail_t*
+	bool preview_has_won;
+	bool lock_if_preview_solves;
 
 	// ui button templates
 	void* ui_buttons; // actual type: ui_button_collection*

--- a/src/arena_algorithm.cpp
+++ b/src/arena_algorithm.cpp
@@ -38,6 +38,7 @@ extern "C" void tick_func(void *arg)
         if(the_arena->preview_design == nullptr || the_arena->preview_design->modcount != the_arena->design.modcount) {
             // refresh preview design
             // manually clear old data
+            the_arena->preview_has_won = false;
             if(the_arena->preview_world) {
                 free_world(the_arena->preview_world, the_arena->preview_design);
             }
@@ -56,6 +57,9 @@ extern "C" void tick_func(void *arg)
         while(all_trails->accepting()) {
             all_trails->submit_frame(the_arena->preview_design);
             step(the_arena->preview_world);
+            if(goal_blocks_inside_goal_area(the_arena->preview_design)) {
+                the_arena->preview_has_won = true;
+            }
             double time_end = time_precise_ms();
             if(time_end - time_start >= the_arena->tick_ms)break;
         }

--- a/src/arena_graphics.cpp
+++ b/src/arena_graphics.cpp
@@ -627,6 +627,9 @@ void on_button_clicked(arena* arena, ui_button_single& button) {
     if(button.id == ui_button_id{5, 0}) {
         arena->preview_gp_trajectory ^= 1; // toggle
     }
+    if(button.id == ui_button_id{9, 0}) {
+        arena->lock_if_preview_solves ^= 1; // toggle
+    }
 }
 
 void regenerate_ui_buttons(arena* arena) {
@@ -837,6 +840,12 @@ void regenerate_ui_buttons(arena* arena) {
         ui_button_single button{{5, 0}, vw - 30, vh - 30, 70, 50, 2};
         button.texts.push_back(ui_button_text{"Preview", 1, 0, 10});
         button.texts.push_back(ui_button_text{arena->preview_gp_trajectory?"ON":"OFF", 1, 0, -10});
+        all_buttons->buttons.push_back(button);
+    }
+    {
+        ui_button_single button{{9, 0}, vw - 30, vh - 55 - 20 * 0.5f, 70, 20, 2};
+        button.texts.push_back(ui_button_text{"Lock if solve", 1});
+        button.highlighted = arena->lock_if_preview_solves;
         all_buttons->buttons.push_back(button);
     }
 }

--- a/src/arena_graphics.cpp
+++ b/src/arena_graphics.cpp
@@ -843,8 +843,9 @@ void regenerate_ui_buttons(arena* arena) {
         all_buttons->buttons.push_back(button);
     }
     {
-        ui_button_single button{{9, 0}, vw - 30, vh - 55 - 20 * 0.5f, 70, 20, 2};
-        button.texts.push_back(ui_button_text{"Lock if solve", 1});
+        ui_button_single button{{9, 0}, vw - 30, vh - 55 - 30 * 0.5f, 70, 30, 2};
+        button.texts.push_back(ui_button_text{"Lock", 1, 0, 5});
+        button.texts.push_back(ui_button_text{"if solve", 1, 0, -5});
         button.highlighted = arena->lock_if_preview_solves;
         all_buttons->buttons.push_back(button);
     }


### PR DESCRIPTION
* Tiny bit of infrastructure to check if the preview design solves
* New button on the top right to toggle lockout mode
* In lockout mode, if the preview design solves, prevent further changes

No longer lose that one accidental solve! Attain the full power of wiggling!

I don't think this can cause game stability issues, so it is safe to merge immediately.