### PR TITLE
Clamp goal rectangle angle in goal check, add overturned rect graphic

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -618,7 +618,8 @@ static void get_rect_bb(struct shell *shell, struct area *area)
     if (fabs(angle_degrees) >= 32768) {
         angle_degrees = -32768;
     } else {
-        angle_degrees = (int)angle_degrees;
+		// likewise with ftlib, we're not sure enough truncation is a good change
+        // angle_degrees = (int)angle_degrees;
     }
     float angle_radians = angle_degrees * 0.017453292519943295769245;
 

--- a/src/arena.c
+++ b/src/arena.c
@@ -613,8 +613,17 @@ struct block *block_hit_test(struct arena *arena, float x, float y)
 
 static void get_rect_bb(struct shell *shell, struct area *area)
 {
-	float sina = fp_sin(shell->angle);
-	float cosa = fp_cos(shell->angle);
+    // replicate truncation weirdness
+    float angle_degrees = shell->angle * 57.295779513082320876763;
+    if (fabs(angle_degrees) >= 32768) {
+        angle_degrees = -32768;
+    } else {
+        angle_degrees = (int)angle_degrees;
+    }
+    float angle_radians = angle_degrees * 0.017453292519943295769245;
+
+	float sina = fp_sin(angle_radians);
+	float cosa = fp_cos(angle_radians);
 	float wc = shell->rect.w * cosa;
 	float ws = shell->rect.w * sina;
 	float hc = shell->rect.h * cosa;

--- a/src/arena_graphics.cpp
+++ b/src/arena_graphics.cpp
@@ -312,6 +312,12 @@ static void block_graphics_add_rect_single(struct block_graphics *graphics,
 
 static void block_graphics_add_rect(struct block_graphics *graphics,
 				    struct shell shell, int type_id, int z_offset, color overlay) {
+    const double CLAMP_ANGLE = 571.90948929350191576662;
+    if(type_id == FCSIM_GOAL_RECT && std::abs(shell.angle) >= CLAMP_ANGLE) {
+        struct shell shell_copy = shell;
+        shell_copy.angle = -CLAMP_ANGLE;
+        block_graphics_add_rect_single(graphics, shell_copy, alpha_over(get_color_by_type(FCSIM_GOAL_RECT_OVERTURNED, 0), overlay), z_offset + 1);
+    }
     if(graphics->simple_graphics) {
         block_graphics_add_rect_single(graphics, shell, alpha_over(get_color_by_type(type_id, 1), overlay), z_offset + 1);
         return;

--- a/src/graph.c
+++ b/src/graph.c
@@ -121,6 +121,7 @@ uint32_t piece_color_table[FCSIM_NUM_TYPES][2] = {
 	{0xffbc6667, 0xfff29291}, // FCSIM_GOAL_AREA
 	{0x00000000, 0xff87bdf1}, // FCSIM_SKY
 	{0xff404886, 0xff3a3b54}, // FCSIM_UI_BUTTON
+	{0xffb8100b, 0xffcf42fe}, // FCSIM_GOAL_RECT_OVERTURNED
 // FCSIM_NUM_TYPES
 };
 

--- a/src/graph.h
+++ b/src/graph.h
@@ -150,7 +150,8 @@ extern struct material water_rod_material;
 #define FCSIM_GOAL_AREA   15
 #define FCSIM_SKY 16
 #define FCSIM_UI_BUTTON 17
-#define FCSIM_NUM_TYPES 18
+#define FCSIM_GOAL_RECT_OVERTURNED 18
+#define FCSIM_NUM_TYPES 19
 
 extern uint32_t piece_color_table[FCSIM_NUM_TYPES][2];
 


### PR DESCRIPTION
Mirrors https://github.com/evenifyouforget/ftlib/pull/35

Closes #45 

* Goal check now uses -2^15 degrees if the angle magnitude is at least 2^15 degrees
* Graphics now shows bright red rectangle to show the "hitbox" being used