### PR TITLE
Add scons to requirements, make GitHub Pages auto-deploy smarter

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -44,7 +44,7 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions Bot"
           git fetch origin main
-          git merge origin/main --no-edit -Xtheirs || {
+          git merge origin/main --no-edit -Xtheirs --allow-unrelated-histories || {
             echo "Merge failed, reverting to last safe state."
             git merge --abort
             exit 1
@@ -76,7 +76,7 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions Bot"
           git fetch origin main
-          git merge origin/main --no-edit -Xtheirs || {
+          git merge origin/main --no-edit -Xtheirs --allow-unrelated-histories || {
             echo "Merge failed, reverting to last safe state."
             git merge --abort
             exit 1

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,19 +32,20 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout deploy branch
         uses: actions/checkout@v4
         with:
-          # Use the source branch for the PR
-          ref: ${{ github.event.pull_request.head.ref }}
+          # Use the deploy branch as the base for the build
+          ref: 'v2.0-beta-build'
 
-      # Merge main into the current branch, keeping main's version on conflicts
-      - name: Merge main branch
+      # Merge PR branch into the deploy branch, keeping PR's version on conflicts
+      - name: Merge PR branch
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions Bot"
-          git fetch origin main
-          git merge origin/main --no-edit -Xtheirs --allow-unrelated-histories || {
+          # Fetch the PR's head commit
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git merge ${{ github.event.pull_request.head.sha }} --no-edit -Xtheirs --allow-unrelated-histories || {
             echo "Merge failed, reverting to last safe state."
             git merge --abort
             exit 1

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,7 @@ name: CI/CD Pipeline for Pages
 on:
   # Runs the entire workflow (build and deploy) on pushes to the main branch
   push:
-    branches: ["main"]
+    branches: ["main", "v2.0-beta-build"]
 
   # Runs only the CI checks on pull requests to the main branch
   pull_request:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,13 +33,34 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: 'v2.0-beta-build'
+
+      # Merge main into the current branch, keeping main's version on conflicts
+      - name: Merge main branch
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions Bot"
+          git fetch origin main
+          git merge origin/main --no-edit -Xtheirs || {
+            echo "Merge failed, reverting to last safe state."
+            git merge --abort
+            exit 1
+          }
+
+      - name: Install requirements
+        run: sh install_requirements.sh
+
+      - name: Build with scons
+        run: scons
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: 'html/'
+          
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,9 +1,13 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+# Workflow for CI checks on PRs and deployment to GitHub Pages on push to main
+name: CI/CD Pipeline for Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs the entire workflow (build and deploy) on pushes to the main branch
   push:
+    branches: ["main"]
+
+  # Runs only the CI checks on pull requests to the main branch
+  pull_request:
     branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
@@ -22,8 +26,40 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
+  # CI Sanity Check job for pull requests
+  ci-check:
+    # This job runs only on pull_request events
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Use the source branch for the PR
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      # Merge main into the current branch, keeping main's version on conflicts
+      - name: Merge main branch
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions Bot"
+          git fetch origin main
+          git merge origin/main --no-edit -Xtheirs || {
+            echo "Merge failed, reverting to last safe state."
+            git merge --abort
+            exit 1
+          }
+
+      - name: Install requirements
+        run: sh install_requirements.sh
+
+      - name: Build with scons
+        run: scons
+      
+  # Deployment job that runs only on push events to the main branch or workflow dispatch
   deploy:
+    # This job runs only on push to main or manual dispatch
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1,4 +1,2 @@
 # Install system depencences by running
 cat requirements.system | xargs sudo apt install -y
-# Install scons
-python3 -m pip install scons

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1,2 +1,4 @@
 # Install system depencences by running
 cat requirements.system | xargs sudo apt install -y
+# Install scons
+python3 -m pip install scons

--- a/requirements.system
+++ b/requirements.system
@@ -2,3 +2,4 @@ clang
 libx11-dev
 libgl-dev
 lld
+scons

--- a/requirements.system
+++ b/requirements.system
@@ -2,4 +2,3 @@ clang
 libx11-dev
 libgl-dev
 lld
-scons


### PR DESCRIPTION
# General development changes

* Added scons to requirements

# Reworked GitHub Pages deployment

* Runs when main or the deploy branch are updated
* Get latest changes from main by attempting to git merge from main and taking the file from main if there's a conflict
* Install requirements from `install_requirements.sh`
* Run scons
* Then, finally deploy to GH Pages
* Do all of the above except the actual deploy on every PR, so it acts as a CI sanity check now. PR CI version also uses the PR branch instead of main

# AI usage disclaimer

yaml was written by Gemini