### PR TITLE
Press . for microscopic jiggles

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -50,6 +50,7 @@ common_sources = [
     "src/str.c",
     "src/text.c",
     "src/xml.c",
+    "src/xoroshiro.cpp",
     "src/box2d/b2BlockAllocator.c",
     "src/box2d/b2Body.cpp",
     "src/box2d/b2BroadPhase.cpp",

--- a/html/main.js
+++ b/html/main.js
@@ -472,6 +472,7 @@ function canvas_draw(timestamp)
 
 function to_key(code)
 {
+	// I have no idea what this numbering system is.
 	if (code == "Space") return 65;
 	if (code == "KeyR") return 27;
 	if (code == "KeyM") return 58;
@@ -492,6 +493,7 @@ function to_key(code)
 	if (code == "Digit0") return 19;
 	if (code == "ShiftLeft") return 50;
 	if (code == "ControlLeft") return 37;
+	if (code == "Period") return 190;
 	return 0;
 }
 

--- a/src/arena.h
+++ b/src/arena.h
@@ -143,6 +143,7 @@ int design_piece_count(struct block_list *list);
 void start_stop(struct arena *arena);
 bool is_running(struct arena *arena);
 void update_tool(struct arena *arena);
+void action_move(struct arena *arena, int x, int y);
 
 extern GLuint block_program;
 extern GLuint block_program_coord_attrib;
@@ -161,5 +162,14 @@ extern int _fcsim_speed_preset;
 #endif
 void change_speed_factor(struct arena *arena, double new_factor, int new_base_fps_mod);
 void change_speed_preset(struct arena *arena, int preset_index);
+
+// microtweaking
+extern double microtweak_dx;
+extern double microtweak_dy;
+void microtweak_jitter();
+void microtweak_reset();
+
+// entropy sources
+void general_prng_add_entropy(uint64_t value);
 
 #endif

--- a/src/arena_algorithm.cpp
+++ b/src/arena_algorithm.cpp
@@ -8,6 +8,7 @@
 #include "arena.hpp"
 #include "stl_compat.h"
 #include "interval.h"
+#include "xoroshiro.hpp"
 
 extern "C" void tick_func(void *arg)
 {
@@ -100,4 +101,16 @@ void multi_trail_t::submit_frame(design* current_design) {
             trail_index++;
 		}
 	}
+}
+
+extern "C" void microtweak_jitter() {
+    int64_t rand_x = (int64_t)(general_prng.next());
+    int64_t rand_y = (int64_t)(general_prng.next());
+    microtweak_dx += rand_x * 1e-30;
+    microtweak_dy += rand_y * 1e-30;
+}
+
+extern "C" void microtweak_reset() {
+    microtweak_dx = 0;
+    microtweak_dy = 0;
 }

--- a/src/xoroshiro.cpp
+++ b/src/xoroshiro.cpp
@@ -1,0 +1,31 @@
+#include "xoroshiro.hpp"
+
+uint64_t xoroshiro256pp::next() {
+    const uint64_t result = rotl(s[0] + s[3], 23) + s[0];
+
+    const uint64_t t = s[1] << 17;
+
+    s[2] ^= s[0];
+    s[3] ^= s[1];
+    s[1] ^= s[2];
+    s[0] ^= s[3];
+
+    s[2] ^= t;
+
+    s[3] = rotl(s[3], 45);
+
+    return result;
+}
+
+void xoroshiro256pp::add_entropy(uint64_t value) {
+    s[0] += value;
+    s[1] += value * 0x3abf7d710007d1a7ull;
+    s[2] += 0x2a0546aec5cd23bull;
+}
+
+xoroshiro256pp general_prng;
+
+// glue code
+extern "C" void general_prng_add_entropy(uint64_t value) {
+    general_prng.add_entropy(value);
+}

--- a/src/xoroshiro.hpp
+++ b/src/xoroshiro.hpp
@@ -1,0 +1,19 @@
+#ifndef XOROSHIRO_HPP
+#define XOROSHIRO_HPP
+
+// adapted from https://prng.di.unimi.it/xoshiro256plusplus.c
+#include <stdint.h>
+
+inline uint64_t rotl(const uint64_t x, int k) {
+	return (x << k) | (x >> (64 - k));
+}
+
+struct xoroshiro256pp {
+    uint64_t s[4];
+    uint64_t next();
+    void add_entropy(uint64_t value);
+};
+
+extern xoroshiro256pp general_prng;
+
+#endif // XOROSHIRO_HPP


### PR DESCRIPTION
# New infrastructure

* Added xoroshiro256++ as a good enough source of randomness
* Used mouse movement to add entropy to the PRNG
* Global variable for microtweak dx, dy that are reset when finishing a move action (to avoid long term drift)

# New keybind: .

* I chose the period key because it looks small
* The keybind is not advertised anywhere on screen, so it's a bit of a hidden keybind (sorry)
* Only useful if you are currently grabbing an object (joint or connected component), otherwise it does nothing
* Will induce a very small random x and y jitter

# Bugs

Saving and reloading the design often results in a different outcome. Seems to have the same accuracy issue as the old autotweaker. Probably some deeper infrastructure is to blame.

I don't want to merge this trash into main.