### PR TITLE
Increase malloc pad space to 180k

### DIFF
--- a/src/arch/wasm/malloc.c
+++ b/src/arch/wasm/malloc.c
@@ -16,7 +16,7 @@
 // and the game does not crash.
 // in the future, if the game is crashing, try setting the pad space higher.
 #ifndef MALLOC_PAD_SPACE
-#define MALLOC_PAD_SPACE 160000
+#define MALLOC_PAD_SPACE 180000
 #endif
 #ifndef MALLOC_MIN_BLOCK
 #define MALLOC_MIN_BLOCK 4


### PR DESCRIPTION
The malloc pad space was originally added because 0 pad space caused some kind of issue. Setting it larger than the program size itself seemed to resolve the bug, so I figured that was the space needed to store the program itself.

At the time, 160k was sufficient. But I just built fcsim and `fcsim.wasm` was 177304 bytes.

This may explain a rare crash one user experienced.

I am increasing the malloc pad space to 180k. If the code size increases significantly again, expect the pad space to be bumped to 200k.