### PR TITLE
Button to open current design in Steam

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -46,6 +46,9 @@ canvas {
 #link {
 	display: none;
 }
+#steam-button {
+    background-color: #6b5ebd;
+}
 #version-button {
     background-color: #c7c96a;
 }
@@ -102,6 +105,7 @@ canvas {
 	<button class="tool" id="account-button"> Account </button>
 	<button class="tool" id="save"> Save </button>
 	<button class="tool" id="version-button"> Version </button>
+	<button class="tool" id="steam-button"> Steam </button>
 	<span id="notification"></span>
 </div>
 <div id="save_menu">

--- a/html/main.js
+++ b/html/main.js
@@ -61,6 +61,7 @@ let version_branch_name  = document.getElementById("version_branch_name");
 let version_is_dirty  = document.getElementById("version_is_dirty");
 let version_sha  = document.getElementById("version_sha");
 let close_version_menu  = document.getElementById("close-version-menu");
+let steam_button  = document.getElementById("steam-button");
 
 let user_id;
 
@@ -654,6 +655,13 @@ if(!design_id && !level_id) {
 
         notification.appendChild(helpDiv);
     }
+
+	function openInSteam() {
+		let steamUrl = "fantasticcontraption1:" + (design_id ? "designId=" + design_id : "levelId=" + level_id);
+		window.location = steamUrl;
+	}
+
+	steam_button.addEventListener('click', openInSteam);
 }
 
 let response_promise = fetch(FC_URL + "/retrieveLevel.php", {


### PR DESCRIPTION
Opens the current level ID or design ID in Steam. Local changes will not be reflected.

Will only work on Windows due to the custom scheme not being registered on Linux.